### PR TITLE
Fix: avoid double-rescaling of images in the BLIP-2 inference pipeline

### DIFF
--- a/hydra_vl4ai/tool/blip.py
+++ b/hydra_vl4ai/tool/blip.py
@@ -52,7 +52,7 @@ class BLIP2Model(BaseModel):
 
     @torch.no_grad()
     def caption(self, image, prompt=None):
-        inputs = self.processor(images=image, text=prompt, return_tensors="pt").to(self.dev)
+        inputs = self.processor(images=image, text=prompt, return_tensors="pt", do_rescale=False).to(self.dev)
         generated_ids = self.model.generate(**inputs, length_penalty=1., num_beams=5, max_length=30, min_length=1,
                                             do_sample=False, top_p=0.9, repetition_penalty=1.0,
                                             num_return_sequences=1, temperature=1)
@@ -78,7 +78,7 @@ class BLIP2Model(BaseModel):
 
     @torch.no_grad()
     def qa(self, image, question):
-        inputs = self.processor(images=image, text=question, return_tensors="pt", padding="longest").to(self.dev)
+        inputs = self.processor(images=image, text=question, return_tensors="pt", padding="longest", do_rescale=False).to(self.dev)
         generated_ids = self.model.generate(**inputs, length_penalty=-1, num_beams=5, max_length=10, min_length=1,
                                             do_sample=False, top_p=0.9, repetition_penalty=1.0,
                                             num_return_sequences=1, temperature=1)


### PR DESCRIPTION
While validating OK-VQA results I noticed that BLIP-2 sometimes produces captions that are clearly unrelated to the input image. After tracing the preprocessing steps I found that the same image is rescaled twice

e.g. 
when use blip2 to caption the first image(COCO_val2014_000000297147.jpg) in okvqa:
![COCO_val2014_000000297147](https://github.com/user-attachments/assets/ef2a48ec-1d2f-4543-92e3-32493b1bc9c0)

the result is "a black and white image of a sculpture"

<img width="1243" alt="Screenshot 2025-06-29 at 01 57 01" src="https://github.com/user-attachments/assets/521ca0e5-4162-4c9e-bf00-e44ae4e76127" />

After tracing the preprocessing steps I found that the same image is rescaled twice:
- torchvision.transforms.ToTensor() converts the PIL.Image to float32 and divides every pixel by 255, putting values in [0, 1].
- Blip2Processor (BlipImageProcessor) then performs its own rescaling, dividing by 255 again and pushing values into [0, 0.0039].

The model therefore “sees” an almost-black image, which explains the degraded caption quality. Transformers even emits the warning:
```pgsql
It looks like you are trying to rescale already rescaled images.
If the input images have pixel values between 0 and 1, set `do_rescale=False`
to avoid rescaling them again.
```
Proposed Change
- set do_rescale=False when calling Blip2Processor